### PR TITLE
I11 timeouts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Copied with minor modifications from wx-files-service
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Lee Zeman <lzeman@uvic.ca>"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:22.04
 
-MAINTAINER Lee Zeman <lzeman@uvic.ca>
+LABEL maintainer="Lee Zeman <lzeman@uvic.ca>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
@@ -23,9 +23,9 @@ RUN poetry install
 
 EXPOSE 8000
 
-ENV FLASK_APP hms.asgi
-ENV FLASK_ENV development
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
+ENV FLASK_APP=hms.asgi
+ENV FLASK_ENV=development
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 
-CMD poetry run uvicorn --port 8000 --host 0.0.0.0 --reload hms.asgi:connexion_app
+CMD ["poetry", "run", "uvicorn", "--port", "8000", "--host", "0.0.0.0", "--workers", "4", "hms.asgi:connexion_app"]

--- a/hms/__init__.py
+++ b/hms/__init__.py
@@ -18,6 +18,10 @@ def create_app():
         SQLALCHEMY_DATABASE_URI=os.getenv("HMS_DSN", ""),
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         SQLALCHEMY_ECHO=False,
+        SQLALCHEMY_ENGINE_OPTIONS={
+            "pool_pre_ping": True,
+            "pool_recycle": int(os.getenv("HMS_DB_POOL_RECYCLE", "3600")),
+        },
     )
     app_db = SQLAlchemy(flask_app)
 

--- a/hms/api/data.py
+++ b/hms/api/data.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime, timedelta
 from functools import lru_cache
 
-from flask import current_app
+from flask import Response, current_app, stream_with_context
 from hydromosaic.database import Outlet, Timeseries, Variable, Scenario, Model, Datafile
 from netCDF4 import Dataset
 from hms import get_app_session
@@ -46,6 +46,21 @@ def basin_name_index_map(parent_dir):
     raise ValueError(f"No basin_name variable found in NetCDF files under {parent_dir}")
 
 
+def time_reference_and_units(time_units_string):
+    if "hours since" in time_units_string:
+        return (
+            datetime.strptime(time_units_string, "hours since %Y-%m-%d %H:%M:%S"),
+            "hours",
+        )
+    elif "days since" in time_units_string:
+        return (
+            datetime.strptime(time_units_string, "days since %Y-%m-%d %H:%M:%S"),
+            "days",
+        )
+    else:
+        raise ValueError(f"Unknown time units: {time_units_string}")
+
+
 def timeseries_data(subid, ts_id):
     """Return a timeseries in CSV format, one metadata table and one timeseries table"""
 
@@ -77,39 +92,29 @@ def timeseries_data(subid, ts_id):
         f"\n"
     )
 
-    # Fetch data from netCDF file, build data table
-    with Dataset(filename) as nc:
-        header = f"Time, {variable_name} ({nc.variables[variable_name].units})\n"
+    @stream_with_context
+    def generate_rows():
+        yield metadata
 
-        basin_names = nc.variables["basin_name"]
-        outlet_index = basin_name_index_map(os.path.dirname(filename))[subid]
-        basin_name = basin_name_string(basin_names[outlet_index])
-        if basin_name != subid:
-            current_app.logger.warning(
-                "Cached basin index mismatch for subid %s in %s; rebuilding from file",
-                subid,
-                filename,
-            )
-            outlet_index = basin_name_index_map_from_values(basin_names)[subid]
-        # timestamps may be given in either hours or days
-        if "hours since" in nc.variables["time"].units:
-            reference_time = datetime.strptime(
-                nc.variables["time"].units, "hours since %Y-%m-%d %H:%M:%S"
-            )
-            time_units = "hours"
-        elif "days since" in nc.variables["time"].units:
-            reference_time = datetime.strptime(
-                nc.variables["time"].units, "days since %Y-%m-%d %H:%M:%S"
-            )
-            time_units = "days"
-        else:
-            raise ValueError(f"Unknown time units: {nc.variables['time'].units}")
+        with Dataset(filename) as nc:
+            yield f"Time, {variable_name} ({nc.variables[variable_name].units})\n"
 
-        timestamps = [
-            time_string(reference_time, time_units, t) for t in nc.variables["time"][:]
-        ]
-        data = nc.variables[variable_name][0 : len(timestamps), outlet_index]
+            basin_names = nc.variables["basin_name"]
+            outlet_index = basin_name_index_map(os.path.dirname(filename))[subid]
+            basin_name = basin_name_string(basin_names[outlet_index])
+            if basin_name != subid:
+                current_app.logger.warning(
+                    "Cached basin index mismatch for subid %s in %s; rebuilding from file",
+                    subid,
+                    filename,
+                )
+                outlet_index = basin_name_index_map_from_values(basin_names)[subid]
 
-    data_rows = [f"{timestamps[i]}, {data[i]}" for i in range(len(timestamps))]
+            reference_time, time_units = time_reference_and_units(nc.variables["time"].units)
+            time_values = nc.variables["time"][:]
+            data_values = nc.variables[variable_name][0 : len(time_values), outlet_index]
 
-    return metadata + header + "\n".join(data_rows)
+            for time_value, data_value in zip(time_values, data_values):
+                yield f"{time_string(reference_time, time_units, time_value)}, {data_value}\n"
+
+    return Response(generate_rows(), mimetype="text/csv")

--- a/hms/api/data.py
+++ b/hms/api/data.py
@@ -1,55 +1,114 @@
+import os
+from datetime import datetime, timedelta
+from functools import lru_cache
+
+from flask import current_app
 from hydromosaic.database import Outlet, Timeseries, Variable, Scenario, Model, Datafile
 from netCDF4 import Dataset
 from hms import get_app_session
-from datetime import datetime, timedelta
-
 
 
 def time_string(reference, units, increment):
     if units == "hours":
-        return (reference + timedelta(hours = increment)).strftime("%Y-%m-%d %H:%M:%S")
+        return (reference + timedelta(hours=increment)).strftime("%Y-%m-%d %H:%M:%S")
     elif units == "days":
-        return (reference + timedelta(days = increment)).strftime("%Y-%m-%d %H:%M:%S")
+        return (reference + timedelta(days=increment)).strftime("%Y-%m-%d %H:%M:%S")
     else:
         raise ValueError(f"Unknown time units: {units}")
+
+
+def basin_name_string(value):
+    if isinstance(value, bytes):
+        return value.decode("utf-8").strip()
+    return str(value).strip()
+
+
+def basin_name_index_map_from_values(basin_names):
+    return {
+        basin_name_string(value): index
+        for index, value in enumerate(basin_names[:].tolist())
+    }
+
+
+@lru_cache(maxsize=32) #32 directory paths
+def basin_name_index_map(parent_dir):
+    for entry in sorted(os.scandir(parent_dir), key=lambda item: item.name):
+        if not entry.is_file() or not entry.name.endswith((".nc")):
+            continue
+
+        with Dataset(entry.path) as nc:
+            basin_names = nc.variables.get("basin_name")
+            if basin_names is None:
+                continue
+
+            return basin_name_index_map_from_values(basin_names)
+
+    raise ValueError(f"No basin_name variable found in NetCDF files under {parent_dir}")
+
 
 def timeseries_data(subid, ts_id):
     """Return a timeseries in CSV format, one metadata table and one timeseries table"""
 
     # Get the metadata from the database, build metadata table
-    ts = get_app_session().query(Timeseries).filter_by(id=ts_id).one()
-    var = get_app_session().query(Variable).filter_by(id=ts.variable_id).one()
-    scen = get_app_session().query(Scenario).filter_by(id=ts.scenario_id).one()
-    mod = get_app_session().query(Model).filter_by(id=ts.model_id).one()
+    _timeseries, variable_name, scenario_name, model_name, filename = (
+        get_app_session()
+        .query(
+            Timeseries,
+            Variable.standard_name,
+            Scenario.short_name,
+            Model.short_name,
+            Datafile.filename,
+        )
+        .join(Variable, Variable.id == Timeseries.variable_id)
+        .join(Scenario, Scenario.id == Timeseries.scenario_id)
+        .join(Model, Model.id == Timeseries.model_id)
+        .join(Datafile, Datafile.id == Timeseries.datafile_id)
+        .join(Outlet, Outlet.id == Timeseries.outlet_id)
+        .filter(Outlet.code == subid, Timeseries.id == ts_id)
+        .one()
+    )
 
     metadata = (
         f"Attribute, Value\n"
-        f"Variable, {var.standard_name}\n"
+        f"Variable, {variable_name}\n"
         f"Outlet, {subid}\n"
-        f"Scenario, {scen.short_name}\n"
-        f"Model, {mod.short_name}\n"
+        f"Scenario, {scenario_name}\n"
+        f"Model, {model_name}\n"
         f"\n"
     )
 
     # Fetch data from netCDF file, build data table
-    df = get_app_session().query(Datafile).filter_by(id=ts.datafile_id).one()
-    nc = Dataset(df.filename)
+    with Dataset(filename) as nc:
+        header = f"Time, {variable_name} ({nc.variables[variable_name].units})\n"
 
-    header = f"Time, {var.standard_name} ({nc.variables[var.standard_name].units})\n"
+        basin_names = nc.variables["basin_name"]
+        outlet_index = basin_name_index_map(os.path.dirname(filename))[subid]
+        basin_name = basin_name_string(basin_names[outlet_index])
+        if basin_name != subid:
+            current_app.logger.warning(
+                "Cached basin index mismatch for subid %s in %s; rebuilding from file",
+                subid,
+                filename,
+            )
+            outlet_index = basin_name_index_map_from_values(basin_names)[subid]
+        # timestamps may be given in either hours or days
+        if "hours since" in nc.variables["time"].units:
+            reference_time = datetime.strptime(
+                nc.variables["time"].units, "hours since %Y-%m-%d %H:%M:%S"
+            )
+            time_units = "hours"
+        elif "days since" in nc.variables["time"].units:
+            reference_time = datetime.strptime(
+                nc.variables["time"].units, "days since %Y-%m-%d %H:%M:%S"
+            )
+            time_units = "days"
+        else:
+            raise ValueError(f"Unknown time units: {nc.variables['time'].units}")
 
-    outlet_index = nc.variables["basin_name"][:].tolist().index(subid)
-    # timestamps may be given in either hours or days
-    if "hours since" in nc.variables['time'].units:
-        reference_time = datetime.strptime(nc.variables['time'].units, "hours since %Y-%m-%d %H:%M:%S")
-        time_units = "hours"
-    elif "days since" in nc.variables['time'].units:
-        reference_time = datetime.strptime(nc.variables['time'].units, "days since %Y-%m-%d %H:%M:%S")
-        time_units = "days"
-    else:
-        raise ValueError(f"Unknown time units: {nc.variables['time'].units}")
-
-    timestamps = [time_string(reference_time, time_units, t) for t in nc.variables["time"][:]]
-    data = nc.variables[var.standard_name][0 : len(timestamps), outlet_index]
+        timestamps = [
+            time_string(reference_time, time_units, t) for t in nc.variables["time"][:]
+        ]
+        data = nc.variables[variable_name][0 : len(timestamps), outlet_index]
 
     data_rows = [f"{timestamps[i]}, {data[i]}" for i in range(len(timestamps))]
 

--- a/hms/api/data.py
+++ b/hms/api/data.py
@@ -7,6 +7,8 @@ from hydromosaic.database import Outlet, Timeseries, Variable, Scenario, Model, 
 from netCDF4 import Dataset
 from hms import get_app_session
 
+ROW_CHUNK_SIZE = int(os.getenv("HMS_NETCDF_ROW_CHUNK_SIZE", "4096"))
+
 
 def time_string(reference, units, increment):
     if units == "hours":
@@ -30,7 +32,7 @@ def basin_name_index_map_from_values(basin_names):
     }
 
 
-@lru_cache(maxsize=32) #32 directory paths
+@lru_cache(maxsize=32) # 32 directory paths
 def basin_name_index_map(parent_dir):
     for entry in sorted(os.scandir(parent_dir), key=lambda item: item.name):
         if not entry.is_file() or not entry.name.endswith((".nc")):
@@ -110,11 +112,16 @@ def timeseries_data(subid, ts_id):
                 )
                 outlet_index = basin_name_index_map_from_values(basin_names)[subid]
 
-            reference_time, time_units = time_reference_and_units(nc.variables["time"].units)
-            time_values = nc.variables["time"][:]
-            data_values = nc.variables[variable_name][0 : len(time_values), outlet_index]
+            time_variable = nc.variables["time"]
+            reference_time, time_units = time_reference_and_units(time_variable.units)
+            num_rows = len(time_variable)
 
-            for time_value, data_value in zip(time_values, data_values):
-                yield f"{time_string(reference_time, time_units, time_value)}, {data_value}\n"
+            for start in range(0, num_rows, ROW_CHUNK_SIZE):
+                stop = min(start + ROW_CHUNK_SIZE, num_rows)
+                time_values = time_variable[start:stop]
+                data_values = nc.variables[variable_name][start:stop, outlet_index]
+
+                for time_value, data_value in zip(time_values, data_values):
+                    yield f"{time_string(reference_time, time_units, time_value)}, {data_value}\n"
 
     return Response(generate_rows(), mimetype="text/csv")

--- a/hms/api/outlets.py
+++ b/hms/api/outlets.py
@@ -4,26 +4,34 @@ from hms import get_app_session
 
 def timeseries_dict(ts, subid, include_outlet=False):
     """helper function that builds a timeseries dict from a Timeseries database object"""
-    var = get_app_session().query(Variable).filter_by(id=ts.variable_id).one()
-    scen = get_app_session().query(Scenario).filter_by(id=ts.scenario_id).one()
-    mod = get_app_session().query(Model).filter_by(id=ts.model_id).one()
+    timeseries, variable_name, scenario_name, model_name = ts
 
     ts = {
-        "id": ts.id,
-        "uri": f"/outlets/{subid}/timeseries/{ts.id}",
-        "data_uri": f"/outlets/{subid}/timeseries/{ts.id}/data",
-        "variable": var.standard_name,
-        "variable_uri": f"/variables/{var.standard_name}",
-        "scenario": scen.short_name,
-        "model": mod.short_name,
-        "start_time": ts.start_time,
-        "end_time": ts.end_time,
-        "num_times": ts.num_times,
+        "id": timeseries.id,
+        "uri": f"/outlets/{subid}/timeseries/{timeseries.id}",
+        "data_uri": f"/outlets/{subid}/timeseries/{timeseries.id}/data",
+        "variable": variable_name,
+        "variable_uri": f"/variables/{variable_name}",
+        "scenario": scenario_name,
+        "model": model_name,
+        "start_time": timeseries.start_time,
+        "end_time": timeseries.end_time,
+        "num_times": timeseries.num_times,
     }
     if include_outlet:
         ts["outlet"] = subid
         ts["outlet_uri"] = f"/outlets/{subid}"
     return ts
+
+
+def timeseries_query():
+    return (
+        get_app_session()
+        .query(Timeseries, Variable.standard_name, Scenario.short_name, Model.short_name)
+        .join(Variable, Variable.id == Timeseries.variable_id)
+        .join(Scenario, Scenario.id == Timeseries.scenario_id)
+        .join(Model, Model.id == Timeseries.model_id)
+    )
 
 
 def list_outlets():
@@ -37,7 +45,7 @@ def outlet(subid):
     """Return detailed data on one outlet"""
     try:
         outlet = get_app_session().query(Outlet).filter_by(code=subid).one()
-        timeseries = get_app_session().query(Timeseries).filter_by(outlet_id=outlet.id)
+        timeseries = timeseries_query().filter(Timeseries.outlet_id == outlet.id).all()
         return {
             "id": outlet.code,
             "uri": f"/outlets/{outlet.code}",
@@ -51,7 +59,7 @@ def list_timeseries(subid):
     """Return all timeseries associated with one outlet"""
     try:
         outlet = get_app_session().query(Outlet).filter_by(code=subid).one()
-        timeseries = get_app_session().query(Timeseries).filter_by(outlet_id=outlet.id)
+        timeseries = timeseries_query().filter(Timeseries.outlet_id == outlet.id).all()
         return [timeseries_dict(t, subid, True) for t in timeseries]
     except:
         return []
@@ -60,8 +68,12 @@ def list_timeseries(subid):
 def timeseries(subid, ts_id):
     """Return detailed information describing one timeseries"""
     try:
-        outlet = get_app_session().query(Outlet).filter_by(code=subid).one()
-        timeseries = get_app_session().query(Timeseries).filter_by(id=ts_id).one()
+        timeseries = (
+            timeseries_query()
+            .join(Outlet, Outlet.id == Timeseries.outlet_id)
+            .filter(Outlet.code == subid, Timeseries.id == ts_id)
+            .one()
+        )
         return timeseries_dict(timeseries, subid, True)
 
     except:

--- a/hms/api/variables.py
+++ b/hms/api/variables.py
@@ -4,16 +4,20 @@ from hms import get_app_session
 
 def list_variables():
     """return a list with an object for each variable in the database"""
-    vars = get_app_session().query(Variable).all()
+    vars = (
+        get_app_session()
+        .query(Variable.standard_name, Variable.units, Variable.long_name)
+        .all()
+    )
 
     return [
         {
-            "id": v.standard_name,
-            "uri": f"/variables/{v.standard_name}",
-            "units": v.units,
-            "long_name": v.long_name,
+            "id": standard_name,
+            "uri": f"/variables/{standard_name}",
+            "units": units,
+            "long_name": long_name,
         }
-        for v in vars
+        for standard_name, units, long_name in vars
     ]
 
 
@@ -21,13 +25,18 @@ def variable(v_id):
     """Return an object representing the requested variable"""
 
     try:
-        var = get_app_session().query(Variable).filter_by(standard_name=v_id).one()
+        standard_name, units, long_name = (
+            get_app_session()
+            .query(Variable.standard_name, Variable.units, Variable.long_name)
+            .filter_by(standard_name=v_id)
+            .one()
+        )
 
         return {
-            "id": var.standard_name,
-            "uri": f"/variables/{var.standard_name}",
-            "units": var.units,
-            "long_name": var.long_name,
+            "id": standard_name,
+            "uri": f"/variables/{standard_name}",
+            "units": units,
+            "long_name": long_name,
         }
     except:
         return {}


### PR DESCRIPTION
Resolves: #11 

- Cache `subid -> outlet_index` lookups instead of repeatedly scanning NetCDF `basin_name`
- Stream timeseries CSV responses
- Read NetCDF data in chunks
- Reduce unnecessary database queries / columns loaded
- ~Improve DB connection handling~ See #13 
- Run uvicorn with multiple workers in Docker